### PR TITLE
Fix scaling bug

### DIFF
--- a/starfish/core/spots/DecodeSpots/check_all_decoder.py
+++ b/starfish/core/spots/DecodeSpots/check_all_decoder.py
@@ -176,6 +176,7 @@ class CheckAll(DecodeSpotsAlgorithm):
             zScale = 1
             yScale = 1
             xScale = 1
+        scaleFactors = (zScale, yScale, xScale)
 
         # Add one to channels labels (prevents collisions between hashes of barcodes later), adds
         # unique spot_id column for each spot in each round, and scales the x, y, and z columns to
@@ -239,21 +240,21 @@ class CheckAll(DecodeSpotsAlgorithm):
         if self.mode == 'high':
             strictnesses = [50, -1]
             seedNumbers = [len(spotTables) - 1, len(spotTables)]
-            minDist = 3 * xScale
+            minDist = 3
             if self.errorRounds == 1:
                 strictnesses.append(1)
                 seedNumbers.append(len(spotTables) - 1)
         elif self.mode == 'med':
             strictnesses = [50, -5]
             seedNumbers = [len(spotTables) - 1, len(spotTables)]
-            minDist = 3 * xScale
+            minDist = 3
             if self.errorRounds == 1:
                 strictnesses.append(5)
                 seedNumbers.append(len(spotTables) - 1)
         elif self.mode == 'low':
             strictnesses = [50, -100]
             seedNumbers = [len(spotTables) - 1, len(spotTables) - 1]
-            minDist = 100 * xScale
+            minDist = 100
             if self.errorRounds == 1:
                 strictnesses.append(10)
                 seedNumbers.append(len(spotTables) - 1)
@@ -351,7 +352,8 @@ class CheckAll(DecodeSpotsAlgorithm):
                                         # values. Adds distance column to roundData
                                         roundData = distanceFilter(roundData, spotCoords,
                                                                    spotQualDict, r,
-                                                                   currentRoundOmitNum, numJobs)
+                                                                   currentRoundOmitNum,
+                                                                   scaleFactors, numJobs)
 
                                         # Match possible barcodes to codebook. Adds target column
                                         # to roundData
@@ -372,7 +374,8 @@ class CheckAll(DecodeSpotsAlgorithm):
                                         # intensity values. Adds distance column to roundData
                                         roundData = distanceFilter(roundData, spotCoords,
                                                                    spotQualDict, r,
-                                                                   currentRoundOmitNum, numJobs)
+                                                                   currentRoundOmitNum,
+                                                                   scaleFactors, numJobs)
 
                                     # Assign to DecodedTables dictionary
                                     decodedTables[r] = roundData


### PR DESCRIPTION
Fixes minor bug introduced in previous PR. Changing the xy scaling distances (say from 1 to 100) changed results slightly when it shouldn't because scoring metric for picking best barcodes uses a combination of the variance in spatial coordinates of spots and their normed intensities and using larger xy scaling factors increases the coordinate values and thus also their variances relative to the normed intensity and results in different scores and sometimes different best barcodes chosen (didn't notice in my small test case but on the full image there was a difference). It now scales the coordinates back down to pixel coordinates and then multiplies them by normed scaling factors calculated by dividing each factor by the min value of all the factors. This is for cases when the z distance isn't significantly larger than the xy distance and spots in a barcode might be in different z slices but we still want to factor in the difference between the z scale and xy scale when calculating the score. Multiplying by these normed factors results in coordinate values more similar in scale to the original coordinates and same for the variances.