### PR TITLE
Fix for using ref image when is_volume=False

### DIFF
--- a/starfish/core/spots/FindSpots/blob.py
+++ b/starfish/core/spots/FindSpots/blob.py
@@ -137,18 +137,11 @@ class BlobDetector(FindSpotsAlgorithm):
 
         # measure intensities
         data_image = np.asarray(data_image)
-        if self.is_volume:
-            z_inds = fitted_blobs_array[:, 0].astype(int)
-            y_inds = fitted_blobs_array[:, 1].astype(int)
-            x_inds = fitted_blobs_array[:, 2].astype(int)
-            radius = np.round(fitted_blobs_array[:, 3] * np.sqrt(3))
-            intensities = data_image[tuple([z_inds, y_inds, x_inds])]
-        else:
-            z_inds = np.asarray([0 for x in range(len(fitted_blobs_array))])
-            y_inds = fitted_blobs_array[:, 0].astype(int)
-            x_inds = fitted_blobs_array[:, 1].astype(int)
-            radius = np.round(fitted_blobs_array[:, 2] * np.sqrt(3))
-            intensities = data_image[tuple([y_inds, x_inds])]
+        z_inds = fitted_blobs_array[:, 0].astype(int)
+        y_inds = fitted_blobs_array[:, 1].astype(int)
+        x_inds = fitted_blobs_array[:, 2].astype(int)
+        radius = np.round(fitted_blobs_array[:, 3] * np.sqrt(3))
+        intensities = data_image[tuple([z_inds, y_inds, x_inds])]
 
         # construct dataframe
         spot_data = pd.DataFrame(


### PR DESCRIPTION
Essentially undoes a fix I made previously that for some reason no longer appears to be necessary. Not sure what happened, maybe the output from the skimage spot finding method changed? Regardless it should work again with this change.