### PR TITLE
float32 -> uint16

### DIFF
--- a/starfish/core/image/Filter/clip_percentile_to_zero.py
+++ b/starfish/core/image/Filter/clip_percentile_to_zero.py
@@ -81,7 +81,7 @@ class ClipPercentileToZero(FilterAlgorithm):
         v_min, v_max = np.percentile(image, [p_min, p_max])
         v_min = min_coeff * v_min
         v_max = max_coeff * v_max
-        return image.clip(min=v_min, max=v_max) - np.float32(v_min)
+        return (image.clip(min=v_min, max=v_max) - np.float32(v_min)).astype('uint16')
 
     def run(self, stack: ImageStack, in_place: bool = False,
             verbose: bool = False, n_processes: Optional[int] = None,

--- a/starfish/core/image/Filter/gaussian_high_pass.py
+++ b/starfish/core/image/Filter/gaussian_high_pass.py
@@ -1,6 +1,7 @@
 from functools import partial
 from typing import Callable, Optional, Tuple, Union
 
+import numpy as np
 import xarray as xr
 
 from starfish.core.image.Filter.gaussian_low_pass import GaussianLowPass
@@ -80,11 +81,12 @@ class GaussianHighPass(FilterAlgorithm):
         -------
         np.ndarray :
             filtered image of the same type and shape as the input image
-        """
-
+        """        
         blurred = GaussianLowPass._low_pass(image, sigma)
-        blurred = levels(blurred)  # clip negative values to 0.
-        filtered = image - blurred
+        #blurred = levels(blurred)  # clip negative values to 0.
+        filtered = image.astype('float32') - blurred
+        filtered.data[filtered.data < 0] = 0
+        filtered = np.rint(filtered).astype('uint16')
 
         return filtered
 
@@ -124,4 +126,5 @@ class GaussianHighPass(FilterAlgorithm):
             group_by=group_by, verbose=verbose, in_place=in_place, n_processes=n_processes,
             level_method=self.level_method
         )
+
         return result

--- a/starfish/core/image/Filter/gaussian_low_pass.py
+++ b/starfish/core/image/Filter/gaussian_low_pass.py
@@ -1,6 +1,7 @@
 from functools import partial
 from typing import Callable, Optional, Tuple, Union
 
+import numpy as np
 import xarray as xr
 from skimage.filters import gaussian
 
@@ -86,7 +87,7 @@ class GaussianLowPass(FilterAlgorithm):
             image,
             sigma=sigma, output=None, cval=0, multichannel=False, preserve_range=True, truncate=4.0
         )
-
+        filtered = np.rint(filtered).astype('uint16')
         return filtered
 
     def run(

--- a/starfish/core/spots/FindSpots/spot_finding_utils.py
+++ b/starfish/core/spots/FindSpots/spot_finding_utils.py
@@ -56,10 +56,19 @@ def measure_intensities_at_spot_locations_in_image(
         # numpy does exclusive max indexing, so need to subtract 1 from min to get centered box
         spots.data[f'{v}_min'] = np.clip(spots.data[v] - (radius - 1), 0, None)
         spots.data[f'{v}_max'] = np.clip(spots.data[v] + radius, None, max_size)
+    '''
     return spots.data[['z_min', 'z_max', 'y_min', 'y_max', 'x_min', 'x_max']].astype(int).apply(
         fn,
         axis=1
     )
+    '''
+    # Does the same as above but above converts values above int16 threshold to negatives and I can't figure out why
+    values = []
+    for row in spots.data[['z_min', 'z_max', 'y_min', 'y_max', 'x_min', 'x_max']].astype('int64').iterrows():
+        row = row[1]
+        d = image[row['z_min']:row['z_max'], row['y_min']:row['y_max'], row['x_min']:row['x_max']]
+        values.append(measurement_function(d))
+    return pd.Series(values, dtype='int64')
 
 
 def measure_intensities_at_spot_locations_across_imagestack(


### PR DESCRIPTION
Changes the data type that starfish uses for it's image arrays from float32 to uint16 (only for the  functions used by PIPEFISH, this probably breaks a lot of other stuff but we don't really care about them). 