### PR TITLE
Fix minor CheckAll bug

### DIFF
--- a/starfish/core/spots/DecodeSpots/check_all_funcs.py
+++ b/starfish/core/spots/DecodeSpots/check_all_funcs.py
@@ -335,11 +335,11 @@ def barcodeBuildFunc(allNeighbors: list,
     # identifier
     allSpotCodes = []
     for neighbors in allNeighbors:
-        neighborLists = [neighbors[rnd] for rnd in range(roundNum)]
         # Adds a 0 to each round of the neighbors dictionary (allows barcodes with dropped
         # rounds to be created)
         if roundOmitNum > 0:
             [neighbors[rnd].append(0) for rnd in range(roundNum)]
+        neighborLists = [neighbors[rnd] for rnd in range(roundNum)]
         # Creates all possible spot code combinations from neighbors
         codes = list(product(*neighborLists))
         # Only save the ones with the correct number of dropped rounds

--- a/starfish/core/spots/DecodeSpots/check_all_funcs.py
+++ b/starfish/core/spots/DecodeSpots/check_all_funcs.py
@@ -338,7 +338,7 @@ def barcodeBuildFunc(allNeighbors: list,
         # Adds a 0 to each round of the neighbors dictionary (allows barcodes with dropped
         # rounds to be created)
         if roundOmitNum > 0:
-            [neighbors[rnd].append(0) for rnd in range(roundNum)]
+            neighbors = [neighbors[rnd] + [0] for rnd in range(roundNum)]
         neighborLists = [neighbors[rnd] for rnd in range(roundNum)]
         # Creates all possible spot code combinations from neighbors
         codes = list(product(*neighborLists))


### PR DESCRIPTION
Fixes minor bug in how barcodes to be decoded are created. Previous version didn't add 0's that represent dropped rounds until after creation of the object used to create the barcodes. This does not affect the final results as the dropped rounds are actually accounted for elsewhere. Also fixes the scope issue in the code.

Fixes hubmapconsortium/spatial-transcriptomics-pipeline#49
